### PR TITLE
Added xsync and updated pair

### DIFF
--- a/pair/pair.go
+++ b/pair/pair.go
@@ -9,8 +9,8 @@ import (
 
 // A Pair holds two values of potentially different types.
 type Pair[T, U any] struct {
-	First  T
-	Second U
+	A T
+	B U
 }
 
 // String returns a string representation of the Pair in the format
@@ -24,7 +24,7 @@ func (p Pair[T, U]) String() string {
 // ignored. If the # flag is set, the type parameters are also included in the
 // format "Pair[T,U]{<First>,<Second>}".
 func (p Pair[T, U]) Format(f fmt.State, _ rune) {
-	a, b := Unpack(p)
+	a, b := p.Unpack()
 	if f.Flag('#') {
 		t := reflect.TypeOf(p)
 		tT := t.Field(0).Type.String()
@@ -35,29 +35,29 @@ func (p Pair[T, U]) Format(f fmt.State, _ rune) {
 	fmt.Fprintf(f, "Pair{%#v,%#v}", a, b)
 }
 
-// New creates a new Pair with the given values.
-func New[T, U any](a T, b U) Pair[T, U] {
-	return Pair[T, U]{First: a, Second: b}
-}
-
 // First returns the first value stored in the Pair.
-func First[T, U any](p Pair[T, U]) T {
-	return p.First
+func (p Pair[T, U]) First() T {
+	return p.A
 }
 
 // Second returns the second value stored in the Pair.
-func Second[T, U any](p Pair[T, U]) U {
-	return p.Second
+func (p Pair[T, U]) Second() U {
+	return p.B
 }
 
 // Unpack returns the two values stored in the Pair.
-func Unpack[T, U any](p Pair[T, U]) (T, U) {
-	return p.First, p.Second
+func (p Pair[T, U]) Unpack() (T, U) {
+	return p.A, p.B
 }
 
 // Swap returns a new Pair with the First and Second values swapped.
-func Swap[T, U any](p Pair[T, U]) Pair[U, T] {
-	return Pair[U, T]{First: p.Second, Second: p.First}
+func (p Pair[T, U]) Swap() Pair[U, T] {
+	return Pair[U, T]{A: p.B, B: p.A}
+}
+
+// Of creates a new Pair with the given values.
+func Of[T, U any](a T, b U) Pair[T, U] {
+	return Pair[T, U]{A: a, B: b}
 }
 
 // Equal compares two Pair values for equality. It returns true if the two
@@ -74,7 +74,7 @@ func Equal[T, U comparable](a, b Pair[T, U]) bool {
 //
 // This only works when both fields implement the Ordered interface.
 func Less[T, U Ordered](a, b Pair[T, U]) bool {
-	return less2(a.First, b.First, a.Second, b.Second)
+	return less2(a.A, b.A, a.B, b.B)
 }
 
 // Compare provides an integer representing the relative order of two Pair
@@ -84,5 +84,5 @@ func Less[T, U Ordered](a, b Pair[T, U]) bool {
 //
 // This only works when both fields implement the Ordered interface.
 func Compare[T, U Ordered](a, b Pair[T, U]) int {
-	return compare2(a.First, b.First, a.Second, b.Second)
+	return compare2(a.A, b.A, a.B, b.B)
 }

--- a/pair/pair_test.go
+++ b/pair/pair_test.go
@@ -12,16 +12,16 @@ func TestEquality(t *testing.T) {
 		a, b  any
 		equal bool
 	}{
-		{New(1, 2), New(1, 2), true},
-		{New(1, 2), New(1, 3), false},
-		{New(1, 2), New(2, 2), false},
-		{New(1, 2), New(2, 1), false},
+		{Of(1, 2), Of(1, 2), true},
+		{Of(1, 2), Of(1, 3), false},
+		{Of(1, 2), Of(2, 2), false},
+		{Of(1, 2), Of(2, 1), false},
 
-		{New(int8(1), int16(2)), New(int8(1), int16(2)), true},
-		{New(int16(1), int8(2)), New(int8(1), int16(2)), false},
+		{Of(int8(1), int16(2)), Of(int8(1), int16(2)), true},
+		{Of(int16(1), int8(2)), Of(int8(1), int16(2)), false},
 
-		{New[any, any](1, 2), New(1, 2), false},
-		{New[any, any](1, 2), New[any, any](1, 2), true},
+		{Of[any, any](1, 2), Of(1, 2), false},
+		{Of[any, any](1, 2), Of[any, any](1, 2), true},
 	}
 
 	for _, tc := range testCases {
@@ -45,11 +45,11 @@ func TestOrdering(t *testing.T) {
 		a, b Pair[string, int]
 		want int
 	}{
-		{New("a", 1), New("a", 2), -1},
-		{New("a", 1), New("b", 1), -1},
-		{New("a", 1), New("a", 1), 0},
-		{New("b", 1), New("a", 1), 1},
-		{New("a", 2), New("a", 1), 1},
+		{Of("a", 1), Of("a", 2), -1},
+		{Of("a", 1), Of("b", 1), -1},
+		{Of("a", 1), Of("a", 1), 0},
+		{Of("b", 1), Of("a", 1), 1},
+		{Of("a", 2), Of("a", 1), 1},
 	}
 
 	for _, tc := range testCases {
@@ -71,24 +71,25 @@ func TestOrdering(t *testing.T) {
 }
 
 func TestInvariants(t *testing.T) {
-	p0 := New(1, "2")
+	assert := assert.New(t)
+	p0 := Of(1, "2")
 
 	// Check accessor functions
-	x, y := Unpack(p0)
-	assert.Exactly(t, p0.First, First(p0), "p0.First != First(p0)")
-	assert.Exactly(t, p0.Second, Second(p0), "p0.Second != Second(p0)")
-	assert.Exactly(t, x, p0.First, "p0.First != Unpack(p0)[0]")
-	assert.Exactly(t, y, p0.Second, "p0.Second != Unpack(p0)[1]")
+	x, y := p0.Unpack()
+	assert.Exactly(p0.A, p0.First(), "p0.A != p0.First()")
+	assert.Exactly(p0.B, p0.Second(), "p0.B != p0.Second()")
+	assert.Exactly(x, p0.A, "p0.A != p0.Unpack()[0]")
+	assert.Exactly(y, p0.B, "p0.B != p0.Unpack()[1]")
 
 	// Check that the fields are swapped
-	p1 := Swap(p0)
-	a, b := Unpack(p0)
-	c, d := Unpack(p1)
-	assert.Exactly(t, a, d, "p0.First != p1.Second")
-	assert.Exactly(t, b, c, "p0.Second != p1.First")
+	p1 := p0.Swap()
+	a, b := p0.Unpack()
+	c, d := p1.Unpack()
+	assert.Exactly(a, d, "p0.A != p1.B")
+	assert.Exactly(b, c, "p0.B != p1.A")
 
 	// Check that the String method matches format "%v"
 	p0s := p0.String()
 	p0f := fmt.Sprintf("%v", p0)
-	assert.Exactly(t, p0s, p0f, "p0.String() != fmt.Sprintf(\"%v\", p0)")
+	assert.Exactly(p0s, p0f, "p0.String() != fmt.Sprintf(\"%v\", p0)")
 }

--- a/xsync/map.go
+++ b/xsync/map.go
@@ -1,0 +1,66 @@
+// Package xsync provides generic wrapper to build-in concurrent types in the
+// sync package of the standard library.
+package xsync
+
+import "sync"
+
+// Map provides a type-safe wrapper around sync.Map. As a result, it is safe to
+// use concurrently and the zero value is ready to use.
+//
+// Aside from the types, all existing APIs are the same as sync.Map for your
+// version of Go. i.e.: m.Clear() will only exist if the Go version is 1.23+.
+//
+// See https://pkg.go.dev/sync#Map for more details on the underlying container.
+type Map[K comparable, V any] struct {
+	m sync.Map
+}
+
+// Load retrieves the value stored in the map for a key, or returns the zero
+// value of the value type and false if no value is present.
+func (m *Map[K, V]) Load(k K) (value V, loaded bool) {
+	v, ok := m.m.Load(k)
+	if !ok {
+		return *new(V), false
+	}
+	return v.(V), true
+}
+
+// Store sets the value for a key in the map.
+func (m *Map[K, V]) Store(k K, v V) {
+	m.m.Store(k, v)
+}
+
+// LoadOrStore loads the value stored in the map for a key, or stores and
+// returns the given value if no value is present. If the value was loaded,
+// then the second return value is true, otherwise on store it is false.
+func (m *Map[K, V]) LoadOrStore(k K, v V) (value V, loaded bool) {
+	v2, load := m.m.LoadOrStore(k, v)
+	return v2.(V), load
+}
+
+// Delete removes the value for a key from the map.
+func (m *Map[K, V]) Delete(k K) {
+	m.m.Delete(k)
+}
+
+// Range calls the provided function f for each key and value present in the map.
+// The function f is called for each element as long as f returns true.
+// The iteration order is not specified and is not guaranteed to be the same
+// across multiple iterations.
+func (m *Map[K, V]) Range(f func(k K, v V) bool) {
+	m.m.Range(func(k, v any) bool {
+		return f(k.(K), v.(V))
+	})
+}
+
+// LoadAndDelete atomically loads and deletes the value stored in the map for a
+// key. It returns the loaded value and a boolean indicating whether the key was
+// present. If the key was not present, the returned value will be the zero
+// value for the value type.
+func (m *Map[K, V]) LoadAndDelete(k K) (value V, loaded bool) {
+	v, ok := m.m.LoadAndDelete(k)
+	if !ok {
+		return *new(V), false
+	}
+	return v.(V), true
+}

--- a/xsync/map_go1.20.go
+++ b/xsync/map_go1.20.go
@@ -1,0 +1,33 @@
+//go:build go1.20
+// +build go1.20
+
+package xsync
+
+// CompareAndDelete compares the value associated with the given key to the provided old value,
+// and if they are equal, deletes the key-value pair from the map. It returns whether the
+// key-value pair was deleted.
+//
+// Requires Go 1.20+.
+func (m *Map[K, V]) CompareAndDelete(k K, old V) (deleted bool) {
+	return m.m.CompareAndDelete(k, old)
+}
+
+// CompareAndSwap compares the value associated with the given key to the provided old value,
+// and if they are equal, sets the value to the new value. It returns whether the value was swapped.
+//
+// Requires Go 1.20+.
+func (m *Map[K, V]) CompareAndSwap(k K, old, new V) (swapped bool) {
+	return m.m.CompareAndSwap(k, old, new)
+}
+
+// Swap sets the value associated with the given key to the new value
+// returning the previous value (if any) and true if the swap replaced an
+// existing value.
+//
+// Requires Go 1.20+.
+func (m *Map[K, V]) Swap(k K, v V) (previous V, swapped bool) {
+	if p, swapped := m.m.Swap(k, v); swapped {
+		return p.(V), true
+	}
+	return *new(V), false
+}

--- a/xsync/map_go1.20_test.go
+++ b/xsync/map_go1.20_test.go
@@ -1,0 +1,49 @@
+//go:build go1.20
+// +build go1.20
+
+package xsync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapCASMethods(t *testing.T) {
+	a := assert.New(t)
+
+	var m Map[string, int]
+	m.Store("one", 11)
+	m.Store("two", 22)
+
+	t.Log("Initial state")
+	checkMap(t, &m, map[string]int{"one": 11, "two": 22})
+
+	m.CompareAndSwap("one", 11, 1)
+	t.Log("After CompareAndSwap of correct value")
+	checkMap(t, &m, map[string]int{"one": 1, "two": 22})
+
+	m.CompareAndSwap("two", 3, 2)
+	t.Log("After CompareAndSwap of incorrect value")
+	checkMap(t, &m, map[string]int{"one": 1, "two": 22})
+
+	m.CompareAndDelete("two", 22)
+	t.Log("After CompareAndDelete of correct value")
+	checkMap(t, &m, map[string]int{"one": 1})
+
+	m.CompareAndDelete("one", 11)
+	t.Log("After CompareAndDelete of incorrect value")
+	checkMap(t, &m, map[string]int{"one": 1})
+
+	old, swap := m.Swap("two", 23)
+	t.Log("After Swap of deleted/non-existant key")
+	a.Zero(old, "Swap should return zero value for missing key")
+	a.False(swap, "Swap should return false for missing key")
+	checkMap(t, &m, map[string]int{"one": 1, "two": 23})
+
+	old, swap = m.Swap("two", 2)
+	t.Log("After Swap of existing key")
+	a.Equal(23, old, "Swap should return previous value for existing key")
+	a.True(swap, "Swap should return true for existing key")
+	checkMap(t, &m, map[string]int{"one": 1, "two": 2})
+}

--- a/xsync/map_go1.23.go
+++ b/xsync/map_go1.23.go
@@ -1,0 +1,11 @@
+//go:build go1.23
+// +build go1.23
+
+package xsync
+
+// Clear removes all key-value pairs from the Map.
+//
+// Requires Go 1.23+.
+func (m *Map[K, V]) Clear() {
+	m.m.Clear()
+}

--- a/xsync/map_test.go
+++ b/xsync/map_test.go
@@ -1,0 +1,79 @@
+package xsync
+
+import (
+	"testing"
+
+	"github.com/cookieo9/go-std-addons/pair"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapInvariants(t *testing.T) {
+	a := assert.New(t)
+	var m Map[string, int]
+
+	t.Log("zero state")
+	a.Equal(0, MapLen(&m), "Length should be zero initially")
+	checkMap(t, &m, map[string]int{})
+
+	x, loaded := m.LoadOrStore("one", 1)
+	t.Log("After first LoadOrStore")
+	a.False(loaded, "First LoadOrStore should return false for loaded")
+	a.Equal(x, 1, "First LoadOrStore should return assigned value")
+	checkMap(t, &m, map[string]int{"one": 1})
+
+	x, loaded = m.LoadOrStore("one", 100)
+	t.Log("After LoadOrStore with existing key")
+	a.True(loaded, "Second LoadOrStore should return true for loaded")
+	a.Equal(x, 1, "Second LoadOrStore should return old value")
+	checkMap(t, &m, map[string]int{"one": 1})
+
+	x, loaded = m.LoadAndDelete("two")
+	t.Log("After LoadAndDelete with missing key")
+	a.False(loaded, "LoadAndDelete should return false for missing key")
+	a.Zero(x, "LoadAndDelete should return zero value for missing key")
+	checkMap(t, &m, map[string]int{"one": 1})
+
+	m.Store("two", 22)
+	t.Log("After store of new key 'two")
+	checkMap(t, &m, map[string]int{"one": 1, "two": 22})
+
+	x, loaded = m.Load("two")
+	t.Log("After Load of existing key")
+	a.True(loaded, "Load should return true for existing key")
+	a.Equal(x, 22, "Load should return stored value")
+	checkMap(t, &m, map[string]int{"one": 1, "two": 22})
+
+	m.Delete("two")
+	t.Log("After Delete of existing key")
+	checkMap(t, &m, map[string]int{"one": 1})
+
+	x, loaded = m.Load("two")
+	t.Log("After Load of deleted key")
+	a.False(loaded, "Load should return false for deleted key")
+	a.Zero(x, "Load should return zero value for deleted key")
+	checkMap(t, &m, map[string]int{"one": 1})
+
+	m.Store("three", 3)
+	t.Log("After Store of new key 'three'")
+	checkMap(t, &m, map[string]int{"one": 1, "three": 3})
+
+	x, loaded = m.LoadAndDelete("three")
+	t.Log("After LoadAndDelete of existing key 'three'")
+	a.True(loaded, "LoadAndDelete should return true for existing key")
+	a.Equal(x, 3, "LoadAndDelete should return stored value")
+	checkMap(t, &m, map[string]int{"one": 1})
+
+	x, loaded = m.Load("three")
+	t.Log("After Load of deleted key 'three'")
+	a.False(loaded, "Load should return false for missing key")
+	a.Zero(x, "Load should return zero value for missing key")
+	checkMap(t, &m, map[string]int{"one": 1})
+
+	m.Store("four", 4)
+	m.Store("five", 5)
+	t.Log("After multiple Stores (with new keys)")
+	checkMap(t, &m, map[string]int{"one": 1, "four": 4, "five": 5})
+	a.Equal(pair.Of(1, true), pair.Of(m.Load("one")), "Load should return 1 for value for 'one'")
+	a.Equal(pair.Of(4, true), pair.Of(m.Load("four")), "Load should return 4 for value for 'four'")
+	a.Equal(pair.Of(5, true), pair.Of(m.Load("five")), "Load should return 5 for value for 'five'")
+}

--- a/xsync/maputils.go
+++ b/xsync/maputils.go
@@ -1,0 +1,42 @@
+package xsync
+
+// Cache retrieves the value stored in the Map for the given key, or computes
+// and stores the value using the provided function if no value is present. If
+// the value was loaded, then the second return value is true, otherwise on
+// compute/store it is false.
+func Cache[K comparable, V any](m *Map[K, V], k K, g func() V) (value V, loaded bool) {
+	if v, ok := m.Load(k); ok {
+		return v, true
+	}
+	return m.LoadOrStore(k, g())
+}
+
+// MapLen computes and returns the number of elements in the given Map.
+//
+// Notes:
+//   - This is not a constant-time operation. (Implemented via Range)
+//   - This is not a safe value to rely on if the Map is being modified
+//     concurrently, as the calculation doesn't prevent the size from changing
+//     even while it is being calculated.
+func MapLen[K comparable, V any](m *Map[K, V]) int {
+	var n int
+	m.m.Range(func(any, any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
+// MapClear clears the contents of the given Map. If the Map implements a Clear
+// method (i.e. in go1.23+), that is used. Otherwise, the Map is cleared by
+// iterating over all keys and deleting them one by one.
+func MapClear[K comparable, V any](m *Map[K, V]) {
+	if clr, ok := any(m).(interface{ Clear() }); ok {
+		clr.Clear()
+		return
+	}
+	m.Range(func(k K, _ V) bool {
+		m.Delete(k)
+		return true
+	})
+}

--- a/xsync/maputils_test.go
+++ b/xsync/maputils_test.go
@@ -1,0 +1,49 @@
+package xsync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapClear(t *testing.T) {
+	// Load initial values
+	var m Map[string, int]
+	m.Store("one", 1)
+	m.Store("two", 2)
+	m.Store("three", 3)
+
+	t.Log("After initial values are loaded")
+	checkMap(t, &m, map[string]int{"one": 1, "two": 2, "three": 3})
+
+	MapClear(&m)
+	t.Log("After Clear")
+	checkMap(t, &m, map[string]int{})
+}
+
+func TestMapCache(t *testing.T) {
+	var m Map[string, int]
+	m.Store("one", 1)
+	m.Store("two", 2)
+
+	t.Log("After initial values are loaded")
+	checkMap(t, &m, map[string]int{"one": 1, "two": 2})
+
+	x, loaded := Cache(&m, "one", func() int { return 10 })
+	t.Log("After Cache of existing key")
+	assert.True(t, loaded, "Cache should return true for existing key")
+	assert.Equal(t, x, 1, "Cache should return stored value")
+	checkMap(t, &m, map[string]int{"one": 1, "two": 2})
+
+	x, loaded = Cache(&m, "one-hundred", func() int { return 100 })
+	t.Log("After Cache of missing key")
+	assert.False(t, loaded, "Cache should return false for missing key")
+	assert.Equal(t, x, 100, "Cache should return computed value")
+	checkMap(t, &m, map[string]int{"one": 1, "two": 2, "one-hundred": 100})
+
+	x, loaded = Cache(&m, "one-hundred", func() int { return 200 })
+	t.Log("After Cache of item previously computed")
+	assert.True(t, loaded, "Cache should return true for previously computed key")
+	assert.Equal(t, x, 100, "Cache should return previously computed value")
+	checkMap(t, &m, map[string]int{"one": 1, "two": 2, "one-hundred": 100})
+}

--- a/xsync/testutils_test.go
+++ b/xsync/testutils_test.go
@@ -1,0 +1,22 @@
+package xsync
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func checkMap(t *testing.T, m *Map[string, int], want map[string]int) {
+	t.Helper()
+
+	// Check length
+	assert.Equal(t, len(want), MapLen(m), "Length should be %d", len(want))
+
+	got := make(map[string]int, len(want))
+	m.Range(func(k string, v int) bool {
+		got[k] = v
+		return true
+	})
+
+	assert.Exactly(t, want, got, "Map should contain expected items")
+}


### PR DESCRIPTION
Added new package `xsync` which provides:
- a type safe generic wrapper around `sync.Map`
  - the API (aside from the types) matches that of `sync.Map` for the building go version.
    - features only added in go1.X to sync.Map will only be present on xsync.Map when building for that version.
    - example: `(xsync.Map).Clear()` will only be present if building in go1.23+
- helper functions for the new `xsync.Map` to add new functionality

Also updated pair package so that it's Pair type operates more like a value type:
- methods to retrieve values (renamed fields as a result)
- function `New()` renamed to `Of()` to not suggest allocation, or returning pointer