### PR TITLE
refactor(xiter/pipe): cleanups

### DIFF
--- a/xerrors/xerrors.go
+++ b/xerrors/xerrors.go
@@ -33,3 +33,12 @@ func CatchValue[T any](f func() T) (value T, err error) {
 	err = Catch(func() { value = f() })
 	return value, err
 }
+
+// Must is a utility function that takes a value and an error, and returns the value.
+// If the error is not nil, Must will panic with the error.
+func Must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/xerrors/xerrors_test.go
+++ b/xerrors/xerrors_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCatch(t *testing.T) {
@@ -63,5 +64,23 @@ func TestCatchValue(t *testing.T) {
 		value, err := CatchValue(f)
 		assert.NoError(t, err, "error should be nil")
 		assert.Equal(t, testValue, value, "value should be returned")
+	})
+}
+
+func TestMust(t *testing.T) {
+	testErr := errors.New("test")
+	testValue := 42
+
+	t.Run("noPanic", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			got := Must(testValue, nil)
+			assert.Equal(t, testValue, got, "value should be returned")
+			Must(testValue, nil)
+		}, "panic should not be thrown")
+	})
+	t.Run("panicWithError", func(t *testing.T) {
+		require.PanicsWithValue(t, testErr, func() {
+			Must(testValue, testErr)
+		}, "panic should be thrown")
 	})
 }

--- a/xiter/pipe/pipe_test.go
+++ b/xiter/pipe/pipe_test.go
@@ -14,12 +14,52 @@ func TestPipeline(t *testing.T) {
 	want := []float64{1.1, 3.3}
 	isOdd := func(x int) bool { return x%2 == 1 }
 
-	got, err := pipe.ProcessSlice[float64](data, pipe.Pipeline(
+	got, err := pipe.ProcessSlice[float64](data,
 		pipe.Filter(isOdd),
 		pipe.Map(func(x int) float64 { return float64(x) * 1.1 }),
 		pipe.While(func(f float64) bool { return f < 4 }),
 		pipe.Materialize[float64](),
-	))
+	)
 	require.NoError(t, err)
 	assert.InEpsilonSlice(t, want, got, 0.0000001, "same sequence")
+}
+
+func TestJoins(t *testing.T) {
+	double := pipe.Map[int](func(x int) int { return x * 2 })
+	odd := pipe.Filter(func(x int) bool { return x%2 == 1 })
+	halfFloat := pipe.Map(func(x float64) float64 { return float64(x) / 2 })
+	testCases := []struct {
+		name         string
+		stages       []pipe.Processor
+		joinErr      assert.ErrorAssertionFunc
+		panicProcess bool
+	}{
+		{name: "no stages"},
+		{name: "double", stages: []pipe.Processor{double}},
+		{name: "odd, double", stages: []pipe.Processor{odd, double}},
+		{name: "double, halfFloat", stages: []pipe.Processor{double, halfFloat}, joinErr: assert.Error},
+		{name: "halfFloat, double", stages: []pipe.Processor{halfFloat, double}, joinErr: assert.Error},
+		{name: "halfFloat", stages: []pipe.Processor{halfFloat}, panicProcess: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := pipe.TryJoin(tc.stages...)
+			if tc.joinErr != nil {
+				tc.joinErr(t, err)
+				return
+			} else {
+				require.NoError(t, err)
+			}
+			if tc.panicProcess {
+				require.Panics(t, func() {
+					pipe.ProcessSlice[int]([]int{1, 2, 3}, p)
+				})
+				return
+			}
+			require.NotPanics(t, func() {
+				pipe.ProcessSlice[int]([]int{1, 2, 3}, p)
+			})
+		})
+	}
 }


### PR DESCRIPTION
Clean up `xiter/pipe` so that it treats invalid pipelines as coding errors (I.e. with a panic) for most functions, but still catches the error on generating a slice in `ProcessSlice`.

Otherwise, turn Pipeline into Join, and make `Process`,`ProcessSlice` simply take a variable length set of processors, passed to Join, to make the Processor to convert iterators.

Added a standard "Must()" function to xerrors, to be used by xiter/pipe.

