### PR TITLE
fix(option): fix small issues

### DIFF
--- a/option/option.go
+++ b/option/option.go
@@ -55,9 +55,9 @@ func (o Value[T]) GetOr(v T) T {
 	return v
 }
 
-// Value returns the value contained in the Value[T]. If the Value[T] is not
+// GetValue returns the value contained in the Value[T]. If the value is not
 // present, the zero value of the type T is returned.
-func (o Value[T]) Value() T {
+func (o Value[T]) GetValue() T {
 	return o.value
 }
 

--- a/option/option_test.go
+++ b/option/option_test.go
@@ -8,49 +8,16 @@ import (
 
 func TestOption(t *testing.T) {
 	x := Some(42)
-
-	v, ok := x.Get()
-	assert.Equal(t, v, 42)
-	assert.Equal(t, x.Value(), 42)
-	assert.Equal(t, x.GetOr(10), 42)
-	assert.True(t, ok)
-	assert.True(t, x.Ok())
-	assert.NotPanics(t, func() {
-		assert.Equal(t, x.Require(), 42)
-	})
+	assertSome(t, x, 42, 101)
 
 	y := None[string]()
-	u, ok := y.Get()
-	assert.Equal(t, u, "")
-	assert.Equal(t, y.Value(), "")
-	assert.Equal(t, y.GetOr("hello"), "hello")
-	assert.False(t, ok)
-	assert.False(t, y.Ok())
-	assert.Panics(t, func() {
-		t.Log("got file:", y.Require())
-	})
+	assertNone(t, y, "hello")
 
 	z := Map(x, func(v int) int { return v * 2 })
-	v, ok = z.Get()
-	assert.Equal(t, v, 84)
-	assert.Equal(t, z.Value(), 84)
-	assert.Equal(t, z.GetOr(10), 84)
-	assert.True(t, ok)
-	assert.True(t, z.Ok())
-	assert.NotPanics(t, func() {
-		assert.Equal(t, z.Require(), 84)
-	})
+	assertSome(t, z, 84, 102)
 
 	q := Map(y, func(v string) int { return len(v) + 5 })
-	v, ok = q.Get()
-	assert.Equal(t, v, 0)
-	assert.Equal(t, q.Value(), 0)
-	assert.Equal(t, q.GetOr(10), 10)
-	assert.False(t, ok)
-	assert.False(t, q.Ok())
-	assert.Panics(t, func() {
-		t.Log("got size:", q.Require())
-	})
+	assertNone(t, q, 103)
 
 	done := false
 	y.Do(func(v string) {
@@ -64,4 +31,35 @@ func TestOption(t *testing.T) {
 		}
 	})
 	assert.True(t, done)
+}
+
+// assertSome checks that the given Value contains the expected value, and that
+// the various accessor methods (Get, GetValue, GetOr, Ok, Require) behave as
+// expected for a Some value.
+func assertSome[T any](t *testing.T, o Value[T], expectedValue, defaultValue T) {
+	v, ok := o.Get()
+	assert.True(t, ok)
+	assert.Equal(t, v, expectedValue)
+	assert.Equal(t, o.GetValue(), expectedValue)
+	assert.Equal(t, o.GetOr(defaultValue), expectedValue)
+	assert.True(t, o.Ok())
+	assert.NotPanics(t, func() {
+		assert.Equal(t, o.Require(), expectedValue)
+	})
+}
+
+// assertNone checks that the given Value contains no value, and that the various
+// accessor methods (Get, GetValue, GetOr, Ok, Require) behave as expected for a
+// None value.
+func assertNone[T any](t *testing.T, o Value[T], defaultValue T) {
+	var zeroValue T
+	v, ok := o.Get()
+	assert.False(t, ok)
+	assert.Equal(t, v, zeroValue)
+	assert.Equal(t, o.GetValue(), zeroValue)
+	assert.Equal(t, o.GetOr(defaultValue), defaultValue)
+	assert.False(t, o.Ok())
+	assert.Panics(t, func() {
+		assert.Equal(t, o.Require(), zeroValue)
+	})
 }


### PR DESCRIPTION
Suggessions by @coderabbitai:
  - Name Value() method to something else
  - use helpers in tests to validate Some/None values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Renamed method for retrieving values in the option package from `Value()` to `GetValue()` for improved clarity.
	- Introduced helper functions `assertSome` and `assertNone` to enhance test readability and maintainability.

- **Bug Fixes**
	- No functional changes, but improved method naming clarifies expected behavior. 

- **Tests**
	- Streamlined test suite for the `option` package to improve verification of `Some` and `None` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->